### PR TITLE
new_request: handling connection timeouts

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"encoding/json"
 	"io/ioutil"
 	"strings"
-	"context"
+//	"context"
 //	"html"
 	"strconv"
 	"time"
@@ -427,14 +428,22 @@ func getCryptoCurrency(url, code string) string {
 
 func new_request(url string) string {
 	var answer string = ""
-	t := time.Now().Add(2 * time.Second)
-	ctx, cancel := context.WithDeadline(context.Background(), t)
-	defer cancel()
-	client := &http.Client{Timeout: 2 * time.Second}
-	reqm, _ := http.NewRequestWithContext(ctx, "GET", url, nil)
+//	t := time.Now().Add(2 * time.Second)
+//	ctx, cancel := context.WithCancel(context.TODO())
+	client := &http.Client{
+		Transport: &http.Transport{
+			Dial: (&net.Dialer{
+			Timeout:   2 * time.Second,
+			KeepAlive: 2 * time.Second,
+			}).Dial,
+		TLSHandshakeTimeout:   2 * time.Second,
+		ResponseHeaderTimeout: 2 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		},
+	}
+	reqm, _ := http.NewRequest("GET", url, nil)
 	reqm.Header.Set("Content-Type", "text/html")
 	content, err := client.Do(reqm)
-
 	if err != nil {
 		fmt.Println(err)
 		if content != nil {


### PR DESCRIPTION
In last couple of days there were some outage for wttr.in that meant long waiting to load the main page. I think this pull request should tackle it so in the end at worst it should take around 15 seconds, instead a minute or more. I have already done some commits on this topic, but I didn't realize the problem is mainly in this case with establishing connection at first. That didn't solve any previous commits. I've tested this and I think it should be alright.